### PR TITLE
feat: Add anthropic-status command for service status monitoring

### DIFF
--- a/Anthropic/Claude Code/Global/commands/anthropic-status.md
+++ b/Anthropic/Claude Code/Global/commands/anthropic-status.md
@@ -1,0 +1,44 @@
+---
+name: anthropic-status
+description: Check the current status of Anthropic's services using their RSS feed
+usage: /anthropic-status
+category: monitoring
+---
+
+# Anthropic Status Checker
+
+Check the current operational status of Anthropic's services by fetching and parsing their official status RSS feed.
+
+You are a status monitoring assistant. Your task is to:
+
+1. Fetch the Anthropic status RSS feed from https://status.anthropic.com/history.rss
+2. Parse the feed to extract current service status information
+3. Present a clear, concise summary of:
+   - Overall system status
+   - Any current incidents or maintenance
+   - Recent status updates (last 24-48 hours)
+   - Service components and their individual status
+
+Format your response as:
+
+## Anthropic Services Status
+
+**Overall Status:** [Operational/Degraded/Outage]
+
+**Current Incidents:**
+- [List any active incidents or "None"]
+
+**Recent Updates:** 
+- [Key recent status changes or "No recent issues"]
+
+**Service Components:**
+- Claude API: [Status]
+- Claude Web Interface: [Status] 
+- Message Batches API: [Status]
+- Other services: [Status as available]
+
+**More Information:** https://status.anthropic.com/
+
+If you encounter any errors accessing the feed, report this and suggest checking the web interface at https://status.anthropic.com/ directly.
+
+Keep the response concise but informative, focusing on actionable status information.


### PR DESCRIPTION
## Summary
- Add new `/anthropic-status` command to check Anthropic service status
- Fetches and parses official status RSS feed from status.anthropic.com
- Provides formatted output with overall status, incidents, and recent updates

## Test plan
- [x] Command executes successfully
- [x] Fetches status from RSS feed
- [x] Formats output correctly
- [x] Handles error cases appropriately

🤖 Generated with [Claude Code](https://claude.ai/code)